### PR TITLE
Fix I and D cache synchronization issue

### DIFF
--- a/boot/start.S
+++ b/boot/start.S
@@ -108,6 +108,8 @@ _start:
 	j .LwaitOtherHart
 
 .enter_uboot:
+	# Synchronize the instruction and data caches.
+	fence.i
 	li t0, DEFAULT_UBOOT_ADDR
 	csrr a0, mhartid
 	la a1, 0


### PR DESCRIPTION
I-cache is not coherent with memory and also with D-cache so after copying data from flash and before jumping to the next software stack we must use the Instruction-Fetch Fence to make sure I and D caches are synchronized to PoU.